### PR TITLE
CLI 0.2.2 Added shutdown 

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@forgehive/forge-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript CLI application",
   "license": "MIT",
   "main": "dist/index.js",

--- a/apps/cli/src/runner.ts
+++ b/apps/cli/src/runner.ts
@@ -134,6 +134,10 @@ runner.setHandler(async (data: ParsedArgs): Promise<unknown> => {
         stack: err.stack
       }
     }
+  } finally {
+    setTimeout(() => {
+      process.exit(0)
+    }, 500)
   }
 })
 


### PR DESCRIPTION
To cli runner to end the process even if connections to mongo are happening. Maybe at some point will need to expose a pre flight and shutdown functions, but not today.